### PR TITLE
Convert recursively directly in the output directory

### DIFF
--- a/kepubify.go
+++ b/kepubify.go
@@ -124,7 +124,7 @@ func main() {
 			paths[f] = filepath.Join(out, strings.Replace(filepath.Base(f), ".epub", "", -1)+".kepub.epub")
 			logV("  file-result: %s -> %s\n", f, paths[f])
 		} else if isDir(arg) {
-			argabs, err := filepath.Abs(arg)
+			_, err := filepath.Abs(arg)
 			if err != nil {
 				logE("Error resolving path for dir '%s'\n", arg)
 				errExit()
@@ -153,7 +153,7 @@ func main() {
 					errExit()
 				}
 
-				paths[abs] = filepath.Join(out, filepath.Base(argabs)+"_converted", rel)
+				paths[abs] = filepath.Join(out, rel)
 				logV("    dir-result: %s -> %s\n", abs, paths[abs])
 			}
 		} else {


### PR DESCRIPTION
The "_converted" behavior can't be used with -u in sync scenarios.

I'm currently syncing epubs on my Kobo but I'd like to have the original epubs only on the computer and have all kepubs on my Kobo. If I mount the Kobo and run kepubify with my modification, I can use the -u flag to sync between my library and the Kobo's root directory (unidirectional sync, that's ok, it's what I want).

This might be a very personal use-case scenario, but I thought I'd contribute the patch anyway. Maybe we can discuss this scenario and use another approach (e.g. another command line flag?)